### PR TITLE
Image/FeatureImage Tag removes alt/caption on empty json value

### DIFF
--- a/tests/data/html/featuredimage.html
+++ b/tests/data/html/featuredimage.html
@@ -1,1 +1,1 @@
-<figure class="featured-image"><picture><img src="https://placekitten.com/200/301" alt="Brown Kitten Image"></picture><figcaption> Cute Kitty </figcaption></figure>
+<figure class="featured-image"><picture><img src="https://placekitten.com/200/301" alt="Brown Kitten Image"></picture></figure>

--- a/tests/data/html/image.html
+++ b/tests/data/html/image.html
@@ -1,1 +1,1 @@
-<figure><img src="https://placekitten.com/200/301" alt="Brown Kitten Image"><figcaption> Cute Kitty </figcaption></figure>
+<figure><img src="https://placekitten.com/200/301"><figcaption> Cute Kitty </figcaption></figure>

--- a/tests/data/json/featuredimage.json
+++ b/tests/data/json/featuredimage.json
@@ -3,6 +3,6 @@
   "attrs": {
     "src": "https://placekitten.com/200/301",
     "alt": "Brown Kitten Image",
-    "caption": "Cute Kitty"
+    "caption": " "
   }
 }

--- a/tests/data/json/image.json
+++ b/tests/data/json/image.json
@@ -2,7 +2,7 @@
   "type": "image",
   "attrs": {
     "src": "https://placekitten.com/200/301",
-    "alt": "Brown Kitten Image",
+    "alt": "  ",
     "caption": "Cute Kitty"
   }
 }

--- a/tiptapy/__init__.py
+++ b/tiptapy/__init__.py
@@ -60,13 +60,12 @@ class Image(BaseNode):
         attrs = node.get("attrs", {})
         attrs_s = " ".join(f'{k}="{v}"'
                            for k, v in attrs.items()
-                           if k not in special_attrs_map
+                           if k not in special_attrs_map and v.strip()
                            )
         html = f"<img {attrs_s}>"
-        for attr in special_attrs_map:
-            if attr in attrs:
-                tag = special_attrs_map[attr]
-                html += f"<{tag}> {attrs[attr]} </{tag}>"
+        if attrs.get('caption').strip():
+            tag = special_attrs_map['caption']
+            html += f"<{tag}> {attrs['caption']} </{tag}>"
         return html
 
 

--- a/tiptapy/extras.py
+++ b/tiptapy/extras.py
@@ -9,13 +9,12 @@ class FeaturedImage(BaseNode):
         attrs = node.get("attrs", {})
         attrs_s = " ".join(f'{k}="{v}"'
                            for k, v in attrs.items()
-                           if k not in special_attrs_map
+                           if k not in special_attrs_map and v.strip()
                            )
         html = f"<picture><img {attrs_s}></picture>"
-        for attr in special_attrs_map:
-            if attr in attrs:
-                tag = special_attrs_map[attr]
-                html += f"<{tag}> {attrs[attr]} </{tag}>"
+        if attrs.get('caption').strip():
+            tag = special_attrs_map['caption']
+            html += f"<{tag}> {attrs['caption']} </{tag}>"
         return f'<figure class="featured-image">{html}</figure>'
 
 


### PR DESCRIPTION
* Image/FeatureImage Tag removes alt/caption on empty json value

#### Image Tag
JSON:
```
{
  "type": "image",
  "attrs": {
    "src": "https://placekitten.com/200/301",
    "alt": "",
    "caption": "Cute Kitty"
  }
}
```
Output:
```
<figure><img src="https://placekitten.com/200/301"><figcaption> Cute Kitty </figcaption></figure>
```


#### FeaturedImage Tag
JSON:
```
{
  "type": "featuredimage",
  "attrs": {
    "src": "https://placekitten.com/200/301",
    "alt": "Brown Kitten Image",
    "caption": ""
  }
}
```

Output:
```
<figure class="featured-image"><picture><img src="https://placekitten.com/200/301" alt="Brown Kitten Image"></picture></figure>

```