### PR TITLE
Image/FeatureImage Remove unwanted space between caption tag

### DIFF
--- a/tests/data/html/image.html
+++ b/tests/data/html/image.html
@@ -1,1 +1,1 @@
-<figure><img src="https://placekitten.com/200/301"><figcaption> Cute Kitty </figcaption></figure>
+<figure><img src="https://placekitten.com/200/301"><figcaption>Cute Kitty</figcaption></figure>

--- a/tiptapy/__init__.py
+++ b/tiptapy/__init__.py
@@ -63,9 +63,9 @@ class Image(BaseNode):
                            if k not in special_attrs_map and v.strip()
                            )
         html = f"<img {attrs_s}>"
-        if attrs.get('caption').strip():
+        if attrs.get('caption', '').strip():
             tag = special_attrs_map['caption']
-            html += f"<{tag}> {attrs['caption']} </{tag}>"
+            html += f"<{tag}>{attrs['caption']}</{tag}>"
         return html
 
 

--- a/tiptapy/extras.py
+++ b/tiptapy/extras.py
@@ -12,9 +12,9 @@ class FeaturedImage(BaseNode):
                            if k not in special_attrs_map and v.strip()
                            )
         html = f"<picture><img {attrs_s}></picture>"
-        if attrs.get('caption').strip():
+        if attrs.get('caption', '').strip():
             tag = special_attrs_map['caption']
-            html += f"<{tag}> {attrs['caption']} </{tag}>"
+            html += f"<{tag}>{attrs['caption']}</{tag}>"
         return f'<figure class="featured-image">{html}</figure>'
 
 


### PR DESCRIPTION
* Removed unwanted space between the `caption` tag

* Added an additional check to check the if `caption` tag is present in the node. 

```
if 'caption' in attrs and attrs.get('caption'):
```

Changes requested in #28 by @gauravr 