### PR TITLE
BugFix: captions not showing for video embeds

### DIFF
--- a/tests/data/html/embed.html
+++ b/tests/data/html/embed.html
@@ -1,1 +1,1 @@
-<iframe width="480" height="270" src="https://www.youtube.com/embed/GJQsT-h0FTU?feature=oembed" frameborder="0"  allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="480" height="270" src="https://www.youtube.com/embed/GJQsT-h0FTU?feature=oembed" frameborder="0"  allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe><figcaption>Extraction</figcaption>

--- a/tiptapy/__init__.py
+++ b/tiptapy/__init__.py
@@ -3,7 +3,7 @@ from typing import Dict
 from inspect import isclass
 
 
-version="__version__ = '0.6.0'",
+version = "__version__ = '0.6.0'",
 renderers: Dict = {}
 
 
@@ -30,6 +30,7 @@ class BaseContainer(BaseNode):
     """
     Base class for container type nodes which may further contain other nodes.
     """
+
     def inner_render(self, nodes: Dict) -> str:
         out = ""
         for node in nodes.get("content", []):
@@ -81,9 +82,12 @@ class Image(BaseNode):
 class Embed(BaseContainer):
     type = "embed"
 
-    def inner_render(self, node):
+    def inner_render(self, node) -> str:
         attrs = node['attrs']
-        return attrs.get('html', '')
+        html = attrs.get('html', '')
+        if attrs.get('type') == 'video' and attrs.get('caption').strip():
+            html += f"<figcaption>{attrs['caption']}</figcaption>"
+        return html
 
 
 class Title(BaseContainer):


### PR DESCRIPTION
* `class Embed(BaseContainer):` gives out a caption tag in the returned HTML for video embeds if the caption is present in the JSON.