### PR TITLE
Adds Heading blocks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+0.6.5 (2020-06-09)
+------------------
+* Heading block added
+
 0.6.4 (2020-06-08)
 ------------------
 * Improved Embed block rendered html output.

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tiptapy",
-    version='0.6.4',  #TODO: why bumpversion works only for single quotes?
+    version='0.6.5',  #TODO: why bumpversion works only for single quotes?
     url="https://github.com/scrolltech/tiptapy",
     description="Library that generates HTML output from JSON export of tiptap editor",
     long_description=open("README.md").read(),

--- a/tests/data/html/heading.html
+++ b/tests/data/html/heading.html
@@ -1,0 +1,1 @@
+<h1>Baby Beets With Horseradish Panna Cotta</h1>

--- a/tests/data/json/heading.json
+++ b/tests/data/json/heading.json
@@ -1,0 +1,7 @@
+{
+  "type": "heading",
+  "attrs": {
+    "level": 1
+  },
+  "content": "Baby Beets With Horseradish Panna Cotta"
+}

--- a/tests/test_tranform.py
+++ b/tests/test_tranform.py
@@ -20,7 +20,8 @@ tags_to_test = (
     "horizontal_rule",
     "embed",
     "embed-missing_caption",
-    "embed-no_caption"
+    "embed-no_caption",
+    "heading"
 )
 
 

--- a/tiptapy/__init__.py
+++ b/tiptapy/__init__.py
@@ -2,7 +2,7 @@ import json
 from typing import Dict
 from inspect import isclass
 
-__version__ = '0.6.4'
+__version__ = '0.6.5'
 
 renderers: Dict = {}
 
@@ -91,6 +91,16 @@ class Embed(BaseContainer):
                 html += f"<figcaption>{caption}</figcaption>"
         provider_name = attrs.get('provider') or 'link'
         return f'<div class="embed-wrapper {provider_name.lower()}-wrapper"><figure>{html}</figure></div>'  # noqa: E501
+
+
+class Heading(BaseContainer):
+    type = "heading"
+
+    def inner_render(self, node) -> str:
+        attrs = node['attrs']
+        level = attrs.get('level') or 3
+        content = node.get('content', '')
+        return f"<h{level}>{content}</h{level}>"
 
 
 class Title(BaseContainer):


### PR DESCRIPTION
* Added heading block that renders heading based on levels. 
* Added tests for heading block. 


* Expected JSON
```JSON
{
  "type": "heading",
  "attrs": {
    "level": 1
  },
  "content": "Baby Beets With Horseradish Panna Cotta"
}
```

* Expected Output
```HTML
<h1>Baby Beets With Horseradish Panna Cotta</h1>
```