### PR TITLE
Heading block accepts nested text content

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+0.6.6 (2020-06-11)
+------------------
+* Improved Heading Block to accept nested text content 
+
 0.6.5 (2020-06-09)
 ------------------
 * Heading block added

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tiptapy",
-    version='0.6.5',  #TODO: why bumpversion works only for single quotes?
+    version='0.6.6',  #TODO: why bumpversion works only for single quotes?
     url="https://github.com/scrolltech/tiptapy",
     description="Library that generates HTML output from JSON export of tiptap editor",
     long_description=open("README.md").read(),

--- a/tests/data/html/heading.html
+++ b/tests/data/html/heading.html
@@ -1,1 +1,1 @@
-<h1>Baby Beets With Horseradish Panna Cotta</h1>
+<h2><strong>This</strong> is a <em>content</em></h2>

--- a/tests/data/json/heading.json
+++ b/tests/data/json/heading.json
@@ -1,7 +1,35 @@
 {
-  "type": "heading",
-  "attrs": {
-    "level": 1
-  },
-  "content": "Baby Beets With Horseradish Panna Cotta"
+  "type": "doc",
+  "content": [
+    {
+      "type": "heading",
+      "attrs": {
+        "level": 2
+      },
+      "content": [
+        {
+          "type": "text",
+          "marks": [
+            {
+              "type": "bold"
+            }
+          ],
+          "text": "This"
+        },
+        {
+          "type": "text",
+          "text": " is a "
+        },
+        {
+          "type": "text",
+          "marks": [
+            {
+              "type": "italic"
+            }
+          ],
+          "text": "content"
+        }
+      ]
+    }
+  ]
 }

--- a/tiptapy/__init__.py
+++ b/tiptapy/__init__.py
@@ -65,7 +65,6 @@ class Heading(Text):
     type = "heading"
 
     def inner_render(self, node) -> str:
-        html = ""
         attrs = node['attrs']
         level = attrs.get('level') or 1
         tag = f"h{level}"

--- a/tiptapy/__init__.py
+++ b/tiptapy/__init__.py
@@ -2,7 +2,7 @@ import json
 from typing import Dict
 from inspect import isclass
 
-__version__ = '0.6.5'
+__version__ = '0.6.6'
 
 renderers: Dict = {}
 
@@ -61,6 +61,23 @@ class Text(BaseNode):
         return text
 
 
+class Heading(Text):
+    type = "heading"
+
+    def inner_render(self, node) -> str:
+        html = ""
+        attrs = node['attrs']
+        level = attrs.get('level') or 3
+        heading_block = f"h{level}"
+        contents = node.get('content')
+        rendered_html = ''
+        if contents:
+            for num in range(len(contents)):
+                html += Text.inner_render(self, contents[num])
+            rendered_html = f"<{heading_block}>{html}</{heading_block}>"
+        return rendered_html
+
+
 class Image(BaseNode):
     type = "image"
     wrap_tag: str = "figure"
@@ -91,16 +108,6 @@ class Embed(BaseContainer):
                 html += f"<figcaption>{caption}</figcaption>"
         provider_name = attrs.get('provider') or 'link'
         return f'<div class="embed-wrapper {provider_name.lower()}-wrapper"><figure>{html}</figure></div>'  # noqa: E501
-
-
-class Heading(BaseContainer):
-    type = "heading"
-
-    def inner_render(self, node) -> str:
-        attrs = node['attrs']
-        level = attrs.get('level') or 3
-        content = node.get('content', '')
-        return f"<h{level}>{content}</h{level}>"
 
 
 class Title(BaseContainer):

--- a/tiptapy/__init__.py
+++ b/tiptapy/__init__.py
@@ -67,15 +67,11 @@ class Heading(Text):
     def inner_render(self, node) -> str:
         html = ""
         attrs = node['attrs']
-        level = attrs.get('level') or 3
-        heading_block = f"h{level}"
-        contents = node.get('content')
-        rendered_html = ''
-        if contents:
-            for num in range(len(contents)):
-                html += Text.inner_render(self, contents[num])
-            rendered_html = f"<{heading_block}>{html}</{heading_block}>"
-        return rendered_html
+        level = attrs.get('level') or 1
+        tag = f"h{level}"
+        cnodes = node.get('content')
+        inner_html = ''.join(Text.inner_render(self, cnode) for cnode in cnodes)
+        return f"<{tag}>{inner_html}</{tag}>"
 
 
 class Image(BaseNode):


### PR DESCRIPTION
* _Heading block_ accepts nested text content that can be `bold`, `plain text`, `italic` or `link`. 

* Updated test for heading block. 

```JSON
{
  "type": "doc",
  "content": [
    {
      "type": "heading",
      "attrs": {
        "level": 2
      },
      "content": [
        {
          "type": "text",
          "marks": [
            {
              "type": "bold"
            }
          ],
          "text": "This"
        },
        {
          "type": "text",
          "text": " is a "
        },
        {
          "type": "text",
          "marks": [
            {
              "type": "italic"
            }
          ],
          "text": "content"
        }
      ]
    }
  ]
}
```

```HTML
<h2><strong>This</strong> is a <em>content</em></h2>
```