### PR TITLE
Standardized anchor tag for known and unkown providers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+0.6.7 (2020-06-17)
+------------------
+* Standardized anchor tag for known and unkown providers 
+
 0.6.6 (2020-06-11)
 ------------------
 * Improved Heading Block to accept nested text content 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tiptapy",
-    version='0.6.6',  #TODO: why bumpversion works only for single quotes?
+    version='0.6.7',  #TODO: why bumpversion works only for single quotes?
     url="https://github.com/scrolltech/tiptapy",
     description="Library that generates HTML output from JSON export of tiptap editor",
     long_description=open("README.md").read(),

--- a/tests/data/html/mark_tags.html
+++ b/tests/data/html/mark_tags.html
@@ -1,1 +1,1 @@
-<p>This is <strong>bold</strong>, this is <em>italic</em> and this has a <a href="https://foobar.withgoogle.com/">link</a></p>
+<p>This is <strong>bold</strong>, this is <em>italic</em> and this has a <a href="https://foobar.withgoogle.com/" target="_blank" rel="noopener nofollow">link</a></p>

--- a/tests/data/json/mark_tags.json
+++ b/tests/data/json/mark_tags.json
@@ -40,7 +40,8 @@
               {
                 "type": "link",
                 "attrs": {
-                  "href": "https://foobar.withgoogle.com/"
+                  "href": "https://foobar.withgoogle.com/",
+                  "title":""
                 }
               }
             ],


### PR DESCRIPTION
* Updated `a` tag to add `target="_blank"` and `rel="noopener nofollow"` if the link is not from a know provider. 

* JSON of **know provider**: 
```JSON
{
  "type": "text",
  "marks": [
    {
      "type": "link",
      "attrs": {
        "href": "https://ritesh.scrollstack.com/post/16",
        "title": "The Battle for Dominance"
      }
    }
  ],
  "text": "The Battle for Dominance - US and China fight to rule India's $1 trillion Digital Economy"
}
```
* Expected HTML output:
```HTML
<a href="https://ritesh.scrollstack.com/post/16" 
title="The Battle for Dominance">
The Battle for Dominance - US and China fight to rule India\'s $1 trillion Digital Economy
</a>
```

* JSON of **unknown provider**

```JSON
{
  "type": "text",
  "marks": [
    {
      "type": "link",
      "attrs": {
        "href": "https://en.wikipedia.org/wiki/Zen_of_Python",
        "title": "Python"
      }
    }
  ],
  "text": "Zen of Python"
}
```
* Expected HTML output:

```HTML
<a href="https://en.wikipedia.org/wiki/Zen_of_Python" 
title="Python" 
target="_blank"
rel="noopener nofollow">
Zen of Python</a>
```
