### PR TITLE
Mandates the use of `is_rendarable` to validate JSON

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 =======
 History
 =======
+0.6.8 (2020-07-03)
+------------------
+* `is_renderable` is made mandatory in render function to validate JSON data.
+
+0.6.7 (2020-07-02)
+------------------
+* Added optional `is_renderable` function in the base node.
 
 0.6.6 (2020-06-11)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tiptapy",
-    version='0.6.7',  #TODO: why bumpversion works only for single quotes?
+    version='0.6.8',  #TODO: why bumpversion works only for single quotes?
     url="https://github.com/scrolltech/tiptapy",
     description="Library that generates HTML output from JSON export of tiptap editor",
     long_description=open("README.md").read(),

--- a/tests/test_tranform.py
+++ b/tests/test_tranform.py
@@ -22,6 +22,7 @@ tags_to_test = (
     "embed-missing_caption",
     "embed-no_caption",
     "heading",
+    "is_renderable",
 )
 
 

--- a/tiptapy/__init__.py
+++ b/tiptapy/__init__.py
@@ -2,7 +2,7 @@ import json
 from typing import Dict
 from inspect import isclass
 
-__version__ = '0.6.7'
+__version__ = '0.6.8'
 
 renderers: Dict = {}
 
@@ -18,17 +18,17 @@ class BaseNode:
 
     def is_renderable(self, node):
         """
-        Suggests if the node is worth rendering.
+        Checks whether the node is worth rendering.
         Example: Image block without src attribute might not.
-        This doesn't affect node rendering however can be considered
-        by high level functions such as convert_any here
         """
         return True
 
     def render(self, in_data) -> str:
-        out = self.inner_render(in_data)
-        if self.wrap_tag:
-            return f"<{self.wrap_tag}>{out}</{self.wrap_tag}>"
+        out = ''
+        if self.is_renderable(in_data):
+            out = self.inner_render(in_data)
+            if self.wrap_tag:
+                out = f"<{self.wrap_tag}>{out}</{self.wrap_tag}>"
         return out
 
     def inner_render(self, node) -> str:
@@ -179,9 +179,7 @@ for o in tuple(locals().values()):
 def convert_any(in_data):
     typ = in_data.get("type")
     renderer = renderers.get(typ)
-    if renderer.is_renderable(in_data):
-        return renderer.render(in_data)
-    return ''
+    return renderer.render(in_data)
 
 
 def to_html(s):


### PR DESCRIPTION
* Adds `is_rendarable` in render to validate JSON node
* Initialize tests for `is_rendarable`
* Removes `is_rendarable` check from convert_any method.