### PR TITLE
Paragraph node with `is_renderable` and `inner_render` method

### DIFF
--- a/tests/data/html/paragraph.html
+++ b/tests/data/html/paragraph.html
@@ -1,0 +1,1 @@
+<p><sup>Quick brown fox jumps over the lazy dog. </sup></p><p>In Penny Lane, there is a barber showing photographs..</p>

--- a/tests/data/json/paragraph.json
+++ b/tests/data/json/paragraph.json
@@ -1,0 +1,28 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "paragraph",
+      "content": [
+        {
+          "type": "text",
+          "marks": [
+            {
+              "type": "sup"
+            }
+          ],
+          "text": "Quick brown fox jumps over the lazy dog. "
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "content": [
+        {
+          "type": "text",
+          "text": "In Penny Lane, there is a barber showing photographs.."
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_tranform.py
+++ b/tests/test_tranform.py
@@ -1,7 +1,6 @@
 import os
 import pytest
 import tiptapy
-import json
 from tiptapy import extras
 
 
@@ -11,6 +10,7 @@ tags_to_test = (
     "bulletlist",
     "mark_tags",
     "ordered_list",
+    "paragraph",
     "image",
     "image-missing_caption",
     "image-no_caption",

--- a/tiptapy/__init__.py
+++ b/tiptapy/__init__.py
@@ -67,7 +67,7 @@ class config:
 
 class Text(BaseNode):
     type = "text"
-    mark_tags = {"bold": "strong", "italic": "em", "link": "a"}
+    mark_tags = {"bold": "strong", "italic": "em", "link": "a", "sup": "sup"}
 
     def inner_render(self, node):
         text = e(node["text"])
@@ -82,7 +82,9 @@ class Text(BaseNode):
                         if not is_trusted_link(url):
                             attrs["target"] = "_blank"
                             attrs["rel"] = "noopener nofollow"
-                    attrs_s = " ".join(f'{k}="{e(v)}"' for k, v in attrs.items())
+                    attrs_s = " ".join(
+                        f'{k}="{e(v)}"' for k, v in attrs.items()
+                    )
                     text = f"<{tag} {attrs_s}>{text}</{tag}>"
                 else:
                     text = f"<{tag}>{text}</{tag}>"
@@ -150,6 +152,18 @@ class Title(BaseContainer):
 class Paragraph(BaseContainer):
     type = "paragraph"
     wrap_tag: str = "p"
+
+    def is_renderable(self, node):
+        text = ''
+        content = node.get('content', [])
+        if content:
+            text = content[0].get('text', '')
+        return bool(text)
+
+    def inner_render(self, node) -> str:
+        content = node.get('content', [])
+        data = content[0]
+        return super().inner_render(node)
 
 
 class BlockQuote(BaseContainer):

--- a/tiptapy/__init__.py
+++ b/tiptapy/__init__.py
@@ -160,11 +160,6 @@ class Paragraph(BaseContainer):
             text = content[0].get('text', '')
         return bool(text)
 
-    def inner_render(self, node) -> str:
-        content = node.get('content', [])
-        data = content[0]
-        return super().inner_render(node)
-
 
 class BlockQuote(BaseContainer):
     type = "blockquote"

--- a/tiptapy/extras.py
+++ b/tiptapy/extras.py
@@ -1,4 +1,4 @@
-from . import Image, register_renderer, e
+from . import Image, register_renderer
 
 
 class FeaturedImage(Image):

--- a/tiptapy/image.py
+++ b/tiptapy/image.py
@@ -8,6 +8,7 @@ class SupportedFormatsMapper(dict):
     def __missing__(self, ext):
         return 'image'
 
+
 SUPPORTED_FORMATS_MAP = SupportedFormatsMapper(
     PNG='image/png',
     JPG='image/jpeg',
@@ -17,6 +18,7 @@ SUPPORTED_FORMATS_MAP = SupportedFormatsMapper(
     WEBP='image/webp',
     SVG='image/svg+xml'
 )
+
 
 def url2mime(url):
     ext = splitext(url)[-1]


### PR DESCRIPTION
* Updated `Text` class to support `sup` tag.
* Paragraph node now has `is_renderable` to validate JSON
* PEP8 fixes in `image.py`
* Removed unused import from `extras.py`
* Removed unused import from `test_tranform.py`