### PR TITLE
Adds stack-document in package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author="Shekhar Tiwatne",
     author_email="pythonic@gmail.com",
     license="http://www.opensource.org/licenses/mit-license.php",
-    package_data={'tiptapy': ['templates/stack-audio-player.html']},
+    package_data={"tiptapy": ["templates/*.html"]},
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
* Adds `'templates/*.html'` in  `setup.py` to add all the HTML files when a new release is made. 

[Link](https://setuptools.readthedocs.io/en/latest/userguide/datafiles.html?highlight=%22data/*.dat%22) to `setuptools` docs with a wildcard example. 